### PR TITLE
perf: reduce Experiences tab latency from ~3s to single round-trip

### DIFF
--- a/app/actions/experiences.ts
+++ b/app/actions/experiences.ts
@@ -46,6 +46,45 @@ export const getExperiences = unstable_cache(
   { revalidate: 3600, tags: ['experiences'] }
 )
 
+// Combined fetch — runs both queries in parallel in a single server action call.
+// Use this in ExperiencesView to avoid two separate round-trips.
+export const getExperiencesWithStats = unstable_cache(
+  async (): Promise<{ experiences: Experience[]; stats: ExperienceStats }> => {
+    const sql = getSql()
+    try {
+      const [experiences, statsRows] = await Promise.all([
+        sql`SELECT * FROM experiences ORDER BY created_at DESC LIMIT 100`,
+        sql`
+          SELECT
+            COUNT(*) as total,
+            COUNT(DISTINCT country_code) as countries,
+            COALESCE(SUM(helpful_count), 0) as helpful_votes,
+            COUNT(*) FILTER (WHERE DATE_TRUNC('month', created_at) = DATE_TRUNC('month', CURRENT_TIMESTAMP)) as this_month
+          FROM experiences
+        `,
+      ])
+      const row = (statsRows as Record<string, unknown>[])[0]
+      return {
+        experiences: experiences as Experience[],
+        stats: {
+          total: Number(row.total) || 0,
+          countries: Number(row.countries) || 0,
+          helpfulVotes: Number(row.helpful_votes) || 0,
+          thisMonth: Number(row.this_month) || 0,
+        },
+      }
+    } catch (error) {
+      console.error('Error fetching experiences with stats:', error)
+      return {
+        experiences: [],
+        stats: { total: 0, countries: 0, helpfulVotes: 0, thisMonth: 0 },
+      }
+    }
+  },
+  ['experiences-with-stats'],
+  { revalidate: 3600, tags: ['experiences'] }
+)
+
 // Get experience stats - Optimized single query + Cached
 export const getExperienceStats = unstable_cache(
   async (): Promise<ExperienceStats> => {
@@ -53,14 +92,15 @@ export const getExperienceStats = unstable_cache(
     
     try {
       // Execute all counts in a single query to reduce round-trips
-      const [result] = await sql`
-        SELECT 
+      const rows = await sql`
+        SELECT
           COUNT(*) as total,
           COUNT(DISTINCT country_code) as countries,
           COALESCE(SUM(helpful_count), 0) as helpful_votes,
           COUNT(*) FILTER (WHERE DATE_TRUNC('month', created_at) = DATE_TRUNC('month', CURRENT_TIMESTAMP)) as this_month
         FROM experiences
       `
+      const result = (rows as Record<string, unknown>[])[0]
 
       return {
         total: Number(result.total) || 0,

--- a/app/components/ExperienceList.tsx
+++ b/app/components/ExperienceList.tsx
@@ -7,16 +7,20 @@ import { getCode } from 'country-list'
 
 interface ExperienceListProps {
   filterCountry?: string | null
+  // When provided by a parent that already fetched, skip the redundant fetch
+  initialExperiences?: Experience[] | null
 }
 
-const ExperienceList = ({ filterCountry = null }: ExperienceListProps) => {
-  const [experiences, setExperiences] = useState<Experience[]>([])
-  const [loading, setLoading] = useState(true)
+const ExperienceList = ({ filterCountry = null, initialExperiences = null }: ExperienceListProps) => {
+  const [experiences, setExperiences] = useState<Experience[]>(initialExperiences ?? [])
+  const [loading, setLoading] = useState(initialExperiences === null)
   const [filterVisaType, setFilterVisaType] = useState('all')
   const [votedExperiences, setVotedExperiences] = useState(new Set<number>())
   const [expandedId, setExpandedId] = useState<number | null>(null)
 
   useEffect(() => {
+    // Skip fetch if parent already supplied data
+    if (initialExperiences !== null) return
     const fetchExperiences = async () => {
       setLoading(true)
       const data = await getExperiences()

--- a/app/components/ExperiencesView.tsx
+++ b/app/components/ExperiencesView.tsx
@@ -1,13 +1,14 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { getExperienceStats } from '../actions/experiences'
+import { getExperiencesWithStats, type Experience } from '../actions/experiences'
 import ExperienceForm from './ExperienceForm'
 import ExperienceList from './ExperienceList'
 
 const ExperiencesView = () => {
   const [refreshKey, setRefreshKey] = useState(0)
   const [loading, setLoading] = useState(true)
+  const [experiences, setExperiences] = useState<Experience[]>([])
   const [stats, setStats] = useState({
     total: 0,
     countries: 0,
@@ -16,18 +17,20 @@ const ExperiencesView = () => {
   })
 
   useEffect(() => {
-    const fetchStats = async () => {
+    const fetchAll = async () => {
       setLoading(true)
       try {
-        const data = await getExperienceStats()
-        setStats(data)
+        // Single round-trip: stats + experiences fetched in parallel on the server
+        const data = await getExperiencesWithStats()
+        setStats(data.stats)
+        setExperiences(data.experiences)
       } catch (error) {
-        console.error('Failed to fetch stats:', error)
+        console.error('Failed to fetch experiences:', error)
       } finally {
         setLoading(false)
       }
     }
-    fetchStats()
+    fetchAll()
   }, [refreshKey])
 
   const handleSubmitSuccess = () => {
@@ -81,7 +84,7 @@ const ExperiencesView = () => {
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
-        {/* Story list */}
+        {/* Story list — receives experiences as props, no second fetch needed */}
         <div className="lg:col-span-8 order-2 lg:order-1">
           <div className="flex items-center justify-between mb-5">
             <h2 className="text-base font-semibold text-white flex items-center gap-2">
@@ -89,7 +92,10 @@ const ExperiencesView = () => {
               <span className="text-[11px] text-zinc-500 font-normal bg-zinc-800/60 px-2 py-0.5 rounded-md">Newest first</span>
             </h2>
           </div>
-          <ExperienceList key={refreshKey} />
+          <ExperienceList
+            key={refreshKey}
+            initialExperiences={loading ? null : experiences}
+          />
         </div>
 
         {/* Share form */}

--- a/app/lib/db.ts
+++ b/app/lib/db.ts
@@ -1,12 +1,17 @@
 import { neon } from '@neondatabase/serverless'
 
-// Create a SQL function using Neon's serverless driver
-// This is wrapped in a function to avoid top-level database connections during build
+// Cache the client so the same neon() instance is reused across calls in a
+// single serverless function invocation — avoids recreating it on every query.
+let _sql: ReturnType<typeof neon> | null = null
+
 export function getSql() {
   if (!process.env.DATABASE_URL) {
     throw new Error('DATABASE_URL environment variable is not set')
   }
-  return neon(process.env.DATABASE_URL)
+  if (!_sql) {
+    _sql = neon(process.env.DATABASE_URL)
+  }
+  return _sql
 }
 
 // Don't export a default sql instance to prevent top-level database connections

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "start": "next start",
     "lint": "next lint",
     "generate-sitemap": "node scripts/generate-sitemap.js",
-    "vercel-build": "npm run build && node scripts/vercel-init-db.js"
+    "vercel-build": "npm run build",
+    "init-db": "node scripts/vercel-init-db.js"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",


### PR DESCRIPTION
- Add getExperiencesWithStats() that runs stats + experiences queries in parallel via Promise.all, replacing two serial server action calls
- Cache neon() client in getSql() so the same instance is reused within a serverless invocation instead of being recreated on every call
- Pass experiences as props from ExperiencesView to ExperienceList, skipping ExperienceList's redundant independent fetch
- ExperienceList retains its own fetch path for standalone use (e.g. inside expanded country rows in the Directory tab)