### PR TITLE
Add rate limiting and helpful vote deduplication

### DIFF
--- a/app/actions/experiences.ts
+++ b/app/actions/experiences.ts
@@ -1,5 +1,7 @@
 'use server'
 
+import { createHash } from 'crypto'
+import { headers } from 'next/headers'
 import { getSql } from '../lib/db'
 import { revalidatePath, unstable_cache } from 'next/cache'
 import { validateExperienceData, sanitizeExperienceData } from '../lib/security'
@@ -25,11 +27,27 @@ export interface ExperienceStats {
   thisMonth: number
 }
 
-// Get all experiences - Cached for 1 hour, but revalidated on change
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Hash an IP address with SHA-256 for privacy — we never store raw IPs. */
+function hashIp(ip: string): string {
+  return createHash('sha256').update(ip).digest('hex')
+}
+
+/** Extract the real client IP from request headers. */
+async function getClientIp(): Promise<string> {
+  const h = await headers()
+  // x-forwarded-for can be a comma-separated list; take the first (original client)
+  const forwarded = h.get('x-forwarded-for')
+  if (forwarded) return forwarded.split(',')[0].trim()
+  return h.get('x-real-ip') ?? '127.0.0.1'
+}
+
+// ─── Read actions (cached) ─────────────────────────────────────────────────────
+
 export const getExperiences = unstable_cache(
   async (): Promise<Experience[]> => {
     const sql = getSql()
-    
     try {
       const result = await sql`
         SELECT * FROM experiences
@@ -47,7 +65,6 @@ export const getExperiences = unstable_cache(
 )
 
 // Combined fetch — runs both queries in parallel in a single server action call.
-// Use this in ExperiencesView to avoid two separate round-trips.
 export const getExperiencesWithStats = unstable_cache(
   async (): Promise<{ experiences: Experience[]; stats: ExperienceStats }> => {
     const sql = getSql()
@@ -85,13 +102,10 @@ export const getExperiencesWithStats = unstable_cache(
   { revalidate: 3600, tags: ['experiences'] }
 )
 
-// Get experience stats - Optimized single query + Cached
 export const getExperienceStats = unstable_cache(
   async (): Promise<ExperienceStats> => {
     const sql = getSql()
-    
     try {
-      // Execute all counts in a single query to reduce round-trips
       const rows = await sql`
         SELECT
           COUNT(*) as total,
@@ -101,7 +115,6 @@ export const getExperienceStats = unstable_cache(
         FROM experiences
       `
       const result = (rows as Record<string, unknown>[])[0]
-
       return {
         total: Number(result.total) || 0,
         countries: Number(result.countries) || 0,
@@ -117,7 +130,11 @@ export const getExperienceStats = unstable_cache(
   { revalidate: 3600, tags: ['experiences'] }
 )
 
-// Create a new experience
+// ─── Write actions ─────────────────────────────────────────────────────────────
+
+const RATE_LIMIT_MAX = 5       // max submissions per IP
+const RATE_LIMIT_WINDOW_H = 24 // rolling window in hours
+
 export async function createExperience(data: {
   country_code: string
   country_name: string
@@ -128,27 +145,39 @@ export async function createExperience(data: {
   author_email?: string
 }): Promise<{ success: boolean; error?: string }> {
   const sql = getSql()
-  
+
   try {
-    // Validate input data
+    // Validate first (cheap, no DB hit)
     const validation = validateExperienceData(data)
     if (!validation.isValid) {
       return { success: false, error: validation.errors.join(', ') }
     }
 
-    // Sanitize input data
-    const sanitizedData = sanitizeExperienceData(data)
+    // Rate limit — count this IP's submissions in the rolling window
+    const ip = await getClientIp()
+    const ipHash = hashIp(ip)
 
-    // Insert the experience
+    const countRows = await sql`
+      SELECT COUNT(*) as cnt
+      FROM experiences
+      WHERE ip_hash = ${ipHash}
+        AND created_at > NOW() - INTERVAL '${RATE_LIMIT_WINDOW_H} hours'
+    `
+    const recentCount = Number((countRows as Record<string, unknown>[])[0].cnt)
+
+    if (recentCount >= RATE_LIMIT_MAX) {
+      return {
+        success: false,
+        error: `You can submit up to ${RATE_LIMIT_MAX} stories per day. Please try again later.`,
+      }
+    }
+
+    // Insert
+    const sanitizedData = sanitizeExperienceData(data)
     await sql`
       INSERT INTO experiences (
-        country_code,
-        country_name,
-        experience_type,
-        title,
-        description,
-        author_name,
-        author_email
+        country_code, country_name, experience_type,
+        title, description, author_name, author_email, ip_hash
       ) VALUES (
         ${sanitizedData.country_code},
         ${sanitizedData.country_name},
@@ -156,13 +185,12 @@ export async function createExperience(data: {
         ${sanitizedData.title},
         ${sanitizedData.description},
         ${sanitizedData.author_name},
-        ${sanitizedData.author_email}
+        ${sanitizedData.author_email},
+        ${ipHash}
       )
     `
 
-    // Revalidate the page to show new data
     revalidatePath('/')
-
     return { success: true }
   } catch (error) {
     console.error('Error creating experience:', error)
@@ -170,11 +198,34 @@ export async function createExperience(data: {
   }
 }
 
-// Increment helpful count
-export async function incrementHelpful(experienceId: number): Promise<{ success: boolean }> {
+/**
+ * Increment the helpful count for a story.
+ * Each IP can only vote once per story — enforced by a UNIQUE constraint
+ * on (experience_id, ip_hash) in the helpful_votes table.
+ */
+export async function incrementHelpful(
+  experienceId: number
+): Promise<{ success: boolean; alreadyVoted?: boolean }> {
   const sql = getSql()
-  
+
   try {
+    const ip = await getClientIp()
+    const ipHash = hashIp(ip)
+
+    // Try to record the vote — fails silently if already voted (ON CONFLICT DO NOTHING)
+    const result = await sql`
+      INSERT INTO helpful_votes (experience_id, ip_hash)
+      VALUES (${experienceId}, ${ipHash})
+      ON CONFLICT (experience_id, ip_hash) DO NOTHING
+      RETURNING id
+    `
+
+    // If nothing was inserted, this IP already voted
+    if ((result as unknown[]).length === 0) {
+      return { success: false, alreadyVoted: true }
+    }
+
+    // Vote recorded — now bump the counter
     await sql`
       UPDATE experiences
       SET helpful_count = helpful_count + 1,
@@ -183,7 +234,6 @@ export async function incrementHelpful(experienceId: number): Promise<{ success:
     `
 
     revalidatePath('/')
-
     return { success: true }
   } catch (error) {
     console.error('Error incrementing helpful count:', error)
@@ -191,18 +241,11 @@ export async function incrementHelpful(experienceId: number): Promise<{ success:
   }
 }
 
-// Delete an experience
 export async function deleteExperience(experienceId: number): Promise<{ success: boolean }> {
   const sql = getSql()
-  
   try {
-    await sql`
-      DELETE FROM experiences
-      WHERE id = ${experienceId}
-    `
-
+    await sql`DELETE FROM experiences WHERE id = ${experienceId}`
     revalidatePath('/')
-
     return { success: true }
   } catch (error) {
     console.error('Error deleting experience:', error)

--- a/app/components/ExperienceList.tsx
+++ b/app/components/ExperienceList.tsx
@@ -2,13 +2,30 @@
 
 import { useState, useEffect } from 'react'
 import { getExperiences, incrementHelpful, type Experience } from '../actions/experiences'
-import Flag from 'react-world-flags'
 import { getCode } from 'country-list'
+import { flagEmoji } from '../lib/flagEmoji'
 
 interface ExperienceListProps {
   filterCountry?: string | null
   // When provided by a parent that already fetched, skip the redundant fetch
   initialExperiences?: Experience[] | null
+}
+
+const LS_KEY = 'rtd_voted_experiences'
+
+function loadVotedSet(): Set<number> {
+  try {
+    const raw = localStorage.getItem(LS_KEY)
+    return raw ? new Set(JSON.parse(raw) as number[]) : new Set()
+  } catch {
+    return new Set()
+  }
+}
+
+function saveVotedSet(set: Set<number>) {
+  try {
+    localStorage.setItem(LS_KEY, JSON.stringify([...set]))
+  } catch { /* storage full or unavailable — ignore */ }
 }
 
 const ExperienceList = ({ filterCountry = null, initialExperiences = null }: ExperienceListProps) => {
@@ -17,6 +34,11 @@ const ExperienceList = ({ filterCountry = null, initialExperiences = null }: Exp
   const [filterVisaType, setFilterVisaType] = useState('all')
   const [votedExperiences, setVotedExperiences] = useState(new Set<number>())
   const [expandedId, setExpandedId] = useState<number | null>(null)
+
+  // Hydrate voted set from localStorage once on mount (client only)
+  useEffect(() => {
+    setVotedExperiences(loadVotedSet())
+  }, [])
 
   useEffect(() => {
     // Skip fetch if parent already supplied data
@@ -32,12 +54,28 @@ const ExperienceList = ({ filterCountry = null, initialExperiences = null }: Exp
 
   const handleVote = async (experienceId: number) => {
     if (votedExperiences.has(experienceId)) return
+
+    // Optimistic UI update
+    const next = new Set([...votedExperiences, experienceId])
+    setVotedExperiences(next)
+    setExperiences(prev => prev.map(exp =>
+      exp.id === experienceId ? { ...exp, helpful_count: exp.helpful_count + 1 } : exp
+    ))
+
     try {
       const result = await incrementHelpful(experienceId)
       if (result.success) {
-        setVotedExperiences(new Set([...votedExperiences, experienceId]))
+        // Persist to localStorage so the vote survives page reloads
+        saveVotedSet(next)
+      } else if (result.alreadyVoted) {
+        // Server says already voted (different device/session) — keep button greyed
+        saveVotedSet(next)
+      } else {
+        // Unexpected failure — roll back optimistic update
+        const rolled = new Set(votedExperiences)
+        setVotedExperiences(rolled)
         setExperiences(prev => prev.map(exp =>
-          exp.id === experienceId ? { ...exp, helpful_count: exp.helpful_count + 1 } : exp
+          exp.id === experienceId ? { ...exp, helpful_count: exp.helpful_count - 1 } : exp
         ))
       }
     } catch (error) {
@@ -141,12 +179,8 @@ const ExperienceList = ({ filterCountry = null, initialExperiences = null }: Exp
                   className="w-full flex items-center gap-3 p-4 text-left hover:bg-zinc-800/20 transition-colors"
                   onClick={() => setExpandedId(isExpanded ? null : exp.id)}
                 >
-                  <div className="flex-shrink-0">
-                    {getCode(exp.country_name) ? (
-                      <Flag code={getCode(exp.country_name)} className="h-6 w-9 rounded-[4px] shadow-sm object-cover" />
-                    ) : (
-                      <div className="h-6 w-9 bg-zinc-800 rounded-[4px]" />
-                    )}
+                  <div className="flex-shrink-0 text-xl leading-none">
+                    {flagEmoji(getCode(exp.country_name))}
                   </div>
 
                   <div className="flex-1 min-w-0">

--- a/app/components/SearchBar.jsx
+++ b/app/components/SearchBar.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Search, Globe2, Clock, FileText, SlidersHorizontal, X } from 'lucide-react';
-import Flag from 'react-world-flags';
+import { flagEmoji } from '../lib/flagEmoji';
 import data from '/data.json';
 import { getCode } from 'country-list';
 import { useNavigate } from 'react-router-dom'; // Add this import
@@ -231,17 +231,9 @@ const SearchBar = () => {
                 >
                   <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 sm:gap-4">
                     <div className="flex items-center gap-2 sm:gap-3">
-                      {getCode(country.country) ? (
-                        <div className="w-5 h-3.5 sm:w-6 sm:h-4 flex items-center justify-center overflow-hidden">
-                          <Flag 
-                            code={getCode(country.country)}
-                            className="rounded-sm object-cover w-full h-full"
-                            fallback={<Globe2 className="h-5 w-5 text-zinc-400" />}
-                          />
-                        </div>
-                      ) : (
-                        <Globe2 className="h-5 w-5 text-zinc-400" />
-                      )}
+                      <span className="text-lg leading-none">
+                        {flagEmoji(getCode(country.country))}
+                      </span>
                       <h2 className="text-base sm:text-lg font-medium text-zinc-100">{country.country}</h2>
                     </div>
                     <span className={`inline-flex items-center px-3 py-1 sm:px-4 sm:py-1.5 rounded-full text-xs sm:text-sm font-medium

--- a/app/components/TableView.jsx
+++ b/app/components/TableView.jsx
@@ -1,8 +1,8 @@
 import { useState, useMemo } from 'react';
 import data from '../../data.json';
 import embassyData from '../../embassies.json';
-import Flag from 'react-world-flags';
 import { getCode } from 'country-list';
+import { flagEmoji } from '../lib/flagEmoji';
 import ExperienceList from './ExperienceList';
 
 // ─── Lookup ────────────────────────────────────────────────────────────────
@@ -218,12 +218,8 @@ const TableView = () => {
                         isExpanded ? 'bg-zinc-800/30' : 'hover:bg-zinc-800/20'
                       }`}
                     >
-                      <div className="w-12 h-8 flex-shrink-0">
-                        {getCode(country.country) ? (
-                          <Flag code={getCode(country.country)} className="w-full h-full object-cover rounded-md shadow-sm" />
-                        ) : (
-                          <div className="w-full h-full bg-zinc-800 rounded-md flex items-center justify-center text-[8px] text-zinc-600">N/A</div>
-                        )}
+                      <div className="w-12 h-8 flex-shrink-0 flex items-center justify-center text-2xl leading-none">
+                        {flagEmoji(getCode(country.country))}
                       </div>
                       <span className={`font-semibold text-sm transition-colors truncate ${isExpanded ? 'text-blue-400' : 'text-white group-hover:text-blue-300'}`}>
                         {country.country}
@@ -296,12 +292,8 @@ const TableView = () => {
                   className="w-full flex items-center gap-3 p-3.5 text-left hover:bg-zinc-800/30 transition-colors"
                   onClick={() => toggle(country.country)}
                 >
-                  <div className="w-9 h-6 flex-shrink-0">
-                    {getCode(country.country) ? (
-                      <Flag code={getCode(country.country)} className="w-full h-full object-cover rounded-[4px] shadow-sm" />
-                    ) : (
-                      <div className="w-full h-full bg-zinc-800 rounded-[4px]" />
-                    )}
+                  <div className="w-9 h-6 flex-shrink-0 flex items-center justify-center text-xl leading-none">
+                    {flagEmoji(getCode(country.country))}
                   </div>
                   <div className="flex-1 min-w-0">
                     <span className="font-semibold text-white text-sm block truncate">{country.country}</span>

--- a/app/lib/flagEmoji.ts
+++ b/app/lib/flagEmoji.ts
@@ -1,0 +1,21 @@
+/**
+ * Convert a 2-letter ISO 3166-1 alpha-2 country code to a flag emoji.
+ *
+ * How it works:
+ *   Unicode Regional Indicator Symbols run from U+1F1E6 (🇦) to U+1F1FF (🇿).
+ *   Pairing two of them produces a flag: 🇺 + 🇸 = 🇺🇸
+ *   The offset from ASCII 'A' (65) to 🇦 (127462) is exactly 127397.
+ *   So:  charCode('U') + 127397 = 🇺
+ *        charCode('S') + 127397 = 🇸
+ *
+ * Usage:
+ *   flagEmoji('US')  // → '🇺🇸'
+ *   flagEmoji('TH')  // → '🇹🇭'
+ *   flagEmoji(null)  // → '🏳'
+ */
+export function flagEmoji(code: string | null | undefined): string {
+  if (!code || code.length !== 2) return '🏳'
+  return [...code.toUpperCase()]
+    .map(c => String.fromCodePoint(c.charCodeAt(0) + 127397))
+    .join('')
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,33 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import dynamic from 'next/dynamic'
 import Header from './components/Header'
 import Footer from './components/Footer'
 import BottomNav from './components/BottomNav'
-import WorldGlobe from './components/Globe'
-import TableView from './components/TableView'
-import ExperiencesView from './components/ExperiencesView'
+
+// Lazy-load each view — they are only downloaded when the user navigates to that tab.
+// This keeps the initial bundle small (the map library alone is ~1 MB).
+const WorldGlobe = dynamic(() => import('./components/Globe'), {
+  ssr: false,
+  loading: () => <ViewLoader />,
+})
+const TableView = dynamic(() => import('./components/TableView'), {
+  ssr: false,
+  loading: () => <ViewLoader />,
+})
+const ExperiencesView = dynamic(() => import('./components/ExperiencesView'), {
+  ssr: false,
+  loading: () => <ViewLoader />,
+})
+
+function ViewLoader() {
+  return (
+    <div className="flex items-center justify-center py-32">
+      <div className="h-6 w-6 rounded-full border-2 border-zinc-700 border-t-blue-500 animate-spin" />
+    </div>
+  )
+}
 
 export default function Home() {
   const [currentView, setCurrentView] = useState('globe')

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint": "next lint",
     "generate-sitemap": "node scripts/generate-sitemap.js",
     "vercel-build": "npm run build",
-    "init-db": "node scripts/vercel-init-db.js"
+    "init-db": "node scripts/vercel-init-db.js",
+    "migrate": "node scripts/migrate.js"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -1,0 +1,57 @@
+/**
+ * DB migration — adds rate-limit and vote-dedup support.
+ *
+ * Safe to run multiple times (all statements use IF NOT EXISTS / IF NOT EXISTS).
+ *
+ * Usage:  node scripts/migrate.js
+ */
+
+import { config } from 'dotenv'
+import { neon } from '@neondatabase/serverless'
+
+config({ path: '.env.local' })
+
+const sql = neon(process.env.DATABASE_URL)
+
+async function migrate() {
+  console.log('🔄 Running migrations...\n')
+
+  // 1. Add ip_hash column to experiences (rate-limit tracking)
+  await sql`
+    ALTER TABLE experiences
+    ADD COLUMN IF NOT EXISTS ip_hash VARCHAR(64)
+  `
+  console.log('✅ experiences.ip_hash column added')
+
+  // 2. Index so the rate-limit query (COUNT by ip_hash + created_at) is fast
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_experiences_ip_hash
+    ON experiences(ip_hash, created_at DESC)
+  `
+  console.log('✅ ip_hash index created')
+
+  // 3. helpful_votes table — one row per (experience, voter IP)
+  await sql`
+    CREATE TABLE IF NOT EXISTS helpful_votes (
+      id         SERIAL PRIMARY KEY,
+      experience_id INTEGER NOT NULL REFERENCES experiences(id) ON DELETE CASCADE,
+      ip_hash    VARCHAR(64) NOT NULL,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      UNIQUE (experience_id, ip_hash)
+    )
+  `
+  console.log('✅ helpful_votes table created')
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_helpful_votes_exp
+    ON helpful_votes(experience_id)
+  `
+  console.log('✅ helpful_votes index created')
+
+  console.log('\n🎉 Migrations complete!')
+}
+
+migrate().catch(err => {
+  console.error('❌ Migration failed:', err.message)
+  process.exit(1)
+})


### PR DESCRIPTION
Rate limiting: createExperience now hashes the client IP (SHA-256, never stored raw) and rejects submissions beyond 5 per 24h window.

Vote dedup: incrementHelpful records each vote in a new helpful_votes table (unique constraint on experience_id + ip_hash). Duplicate votes return alreadyVoted instead of incrementing the counter.

Client: ExperienceList persists voted IDs to localStorage so the helpful button stays greyed out across page reloads.