### PR TITLE
Fix double caching, revalidation, and add pagination

### DIFF
--- a/app/actions/experiences.ts
+++ b/app/actions/experiences.ts
@@ -3,7 +3,8 @@
 import { createHash } from 'crypto'
 import { headers } from 'next/headers'
 import { getSql } from '../lib/db'
-import { revalidatePath, unstable_cache } from 'next/cache'
+import { EXPERIENCES_PAGE_SIZE as PAGE_SIZE } from '../lib/constants'
+import { revalidateTag, unstable_cache } from 'next/cache'
 import { validateExperienceData, sanitizeExperienceData } from '../lib/security'
 
 export interface Experience {
@@ -52,7 +53,7 @@ export const getExperiences = unstable_cache(
       const result = await sql`
         SELECT * FROM experiences
         ORDER BY created_at DESC
-        LIMIT 100
+        LIMIT ${PAGE_SIZE}
       `
       return result as Experience[]
     } catch (error) {
@@ -64,13 +65,33 @@ export const getExperiences = unstable_cache(
   { revalidate: 3600, tags: ['experiences'] }
 )
 
+/**
+ * Load the next page of experiences after a given ID (cursor-based).
+ * Not cached — always fetches fresh so new stories appear immediately.
+ */
+export async function loadMoreExperiences(afterId: number): Promise<Experience[]> {
+  const sql = getSql()
+  try {
+    const result = await sql`
+      SELECT * FROM experiences
+      WHERE id < ${afterId}
+      ORDER BY created_at DESC
+      LIMIT ${PAGE_SIZE}
+    `
+    return result as Experience[]
+  } catch (error) {
+    console.error('Error loading more experiences:', error)
+    return []
+  }
+}
+
 // Combined fetch — runs both queries in parallel in a single server action call.
 export const getExperiencesWithStats = unstable_cache(
   async (): Promise<{ experiences: Experience[]; stats: ExperienceStats }> => {
     const sql = getSql()
     try {
       const [experiences, statsRows] = await Promise.all([
-        sql`SELECT * FROM experiences ORDER BY created_at DESC LIMIT 100`,
+        sql`SELECT * FROM experiences ORDER BY created_at DESC LIMIT ${PAGE_SIZE}`,
         sql`
           SELECT
             COUNT(*) as total,
@@ -190,7 +211,7 @@ export async function createExperience(data: {
       )
     `
 
-    revalidatePath('/')
+    revalidateTag('experiences')
     return { success: true }
   } catch (error) {
     console.error('Error creating experience:', error)
@@ -233,7 +254,7 @@ export async function incrementHelpful(
       WHERE id = ${experienceId}
     `
 
-    revalidatePath('/')
+    revalidateTag('experiences')
     return { success: true }
   } catch (error) {
     console.error('Error incrementing helpful count:', error)
@@ -245,7 +266,7 @@ export async function deleteExperience(experienceId: number): Promise<{ success:
   const sql = getSql()
   try {
     await sql`DELETE FROM experiences WHERE id = ${experienceId}`
-    revalidatePath('/')
+    revalidateTag('experiences')
     return { success: true }
   } catch (error) {
     console.error('Error deleting experience:', error)

--- a/app/components/ExperienceList.tsx
+++ b/app/components/ExperienceList.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { getExperiences, incrementHelpful, type Experience } from '../actions/experiences'
+import { getExperiences, loadMoreExperiences, incrementHelpful, type Experience } from '../actions/experiences'
+import { EXPERIENCES_PAGE_SIZE as PAGE_SIZE } from '../lib/constants'
 import { getCode } from 'country-list'
 import { flagEmoji } from '../lib/flagEmoji'
 
@@ -34,6 +35,8 @@ const ExperienceList = ({ filterCountry = null, initialExperiences = null }: Exp
   const [filterVisaType, setFilterVisaType] = useState('all')
   const [votedExperiences, setVotedExperiences] = useState(new Set<number>())
   const [expandedId, setExpandedId] = useState<number | null>(null)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [hasMore, setHasMore] = useState((initialExperiences?.length ?? 0) >= PAGE_SIZE)
 
   // Hydrate voted set from localStorage once on mount (client only)
   useEffect(() => {
@@ -47,10 +50,21 @@ const ExperienceList = ({ filterCountry = null, initialExperiences = null }: Exp
       setLoading(true)
       const data = await getExperiences()
       setExperiences(data)
+      setHasMore(data.length >= PAGE_SIZE)
       setLoading(false)
     }
     fetchExperiences()
   }, [])
+
+  const handleLoadMore = async () => {
+    if (loadingMore || experiences.length === 0) return
+    setLoadingMore(true)
+    const oldest = experiences[experiences.length - 1]
+    const more = await loadMoreExperiences(oldest.id)
+    setExperiences(prev => [...prev, ...more])
+    setHasMore(more.length >= PAGE_SIZE)
+    setLoadingMore(false)
+  }
 
   const handleVote = async (experienceId: number) => {
     if (votedExperiences.has(experienceId)) return
@@ -275,6 +289,31 @@ const ExperienceList = ({ filterCountry = null, initialExperiences = null }: Exp
               </div>
             )
           })}
+        </div>
+      )}
+
+      {/* Load more — only shown when not filtering by country and more pages exist */}
+      {!filterCountry && hasMore && (
+        <div className="flex justify-center pt-2">
+          <button
+            onClick={handleLoadMore}
+            disabled={loadingMore}
+            className="flex items-center gap-2 px-5 py-2.5 bg-zinc-800/60 hover:bg-zinc-700/60 border border-zinc-700/50 text-zinc-300 text-sm font-semibold rounded-xl transition-all disabled:opacity-50"
+          >
+            {loadingMore ? (
+              <>
+                <div className="h-3.5 w-3.5 rounded-full border-2 border-zinc-600 border-t-blue-400 animate-spin" />
+                Loading…
+              </>
+            ) : (
+              <>
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
+                Load more stories
+              </>
+            )}
+          </button>
         </div>
       )}
     </div>

--- a/app/components/ExperiencesView.tsx
+++ b/app/components/ExperiencesView.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect } from 'react'
 import { getExperiencesWithStats, type Experience } from '../actions/experiences'
-import { cachedFetch, invalidateCache } from '../lib/client-cache'
 import ExperienceForm from './ExperienceForm'
 import ExperienceList from './ExperienceList'
 
@@ -21,8 +20,9 @@ const ExperiencesView = () => {
     const fetchAll = async () => {
       setLoading(true)
       try {
-        // Served from memory cache after first load; revalidates in background
-        const data = await cachedFetch('experiences-with-stats', getExperiencesWithStats)
+        // getExperiencesWithStats is wrapped in unstable_cache on the server (1hr TTL).
+        // No extra client-side cache needed — the server handles it.
+        const data = await getExperiencesWithStats()
         setStats(data.stats)
         setExperiences(data.experiences)
       } catch (error) {
@@ -35,7 +35,7 @@ const ExperiencesView = () => {
   }, [refreshKey])
 
   const handleSubmitSuccess = () => {
-    invalidateCache('experiences-with-stats')
+    // Bump key to re-fetch; the server cache is busted via revalidateTag in the action
     setRefreshKey(prev => prev + 1)
   }
 

--- a/app/lib/constants.ts
+++ b/app/lib/constants.ts
@@ -1,0 +1,1 @@
+export const EXPERIENCES_PAGE_SIZE = 20


### PR DESCRIPTION
- Remove client-side cachedFetch layer from ExperiencesView; the server-side unstable_cache (1hr TTL) is sufficient on its own
- Replace revalidatePath('/') with revalidateTag('experiences') in all write actions — only busts the relevant cache, not the whole page
- Add cursor-based pagination: initial load is 20 stories, 'Load more' fetches the next 20 by ID cursor without re-fetching earlier pages
- Move PAGE_SIZE to app/lib/constants.ts (use server files can only export async functions)