### PR TITLE
Fix Community tab latency: lift fetch to page.tsx

### DIFF
--- a/app/components/ExperiencesView.tsx
+++ b/app/components/ExperiencesView.tsx
@@ -1,42 +1,25 @@
 'use client'
 
-import { useState, useEffect } from 'react'
-import { getExperiencesWithStats, type Experience } from '../actions/experiences'
+import { type Experience } from '../actions/experiences'
 import ExperienceForm from './ExperienceForm'
 import ExperienceList from './ExperienceList'
 
-const ExperiencesView = () => {
-  const [refreshKey, setRefreshKey] = useState(0)
-  const [loading, setLoading] = useState(true)
-  const [experiences, setExperiences] = useState<Experience[]>([])
-  const [stats, setStats] = useState({
-    total: 0,
-    countries: 0,
-    helpfulVotes: 0,
-    thisMonth: 0
-  })
+interface Props {
+  initialData: {
+    experiences: Experience[]
+    stats: { total: number; countries: number; helpfulVotes: number; thisMonth: number }
+  } | null
+  loading: boolean
+  onRefresh: () => void
+}
 
-  useEffect(() => {
-    const fetchAll = async () => {
-      setLoading(true)
-      try {
-        // getExperiencesWithStats is wrapped in unstable_cache on the server (1hr TTL).
-        // No extra client-side cache needed — the server handles it.
-        const data = await getExperiencesWithStats()
-        setStats(data.stats)
-        setExperiences(data.experiences)
-      } catch (error) {
-        console.error('Failed to fetch experiences:', error)
-      } finally {
-        setLoading(false)
-      }
-    }
-    fetchAll()
-  }, [refreshKey])
+const ExperiencesView = ({ initialData, loading, onRefresh }: Props) => {
+  const experiences = initialData?.experiences ?? []
+  const stats = initialData?.stats ?? { total: 0, countries: 0, helpfulVotes: 0, thisMonth: 0 }
 
   const handleSubmitSuccess = () => {
-    // Bump key to re-fetch; the server cache is busted via revalidateTag in the action
-    setRefreshKey(prev => prev + 1)
+    // Tell page.tsx to re-fetch; the server cache is busted via revalidateTag in the action
+    onRefresh()
   }
 
   return (
@@ -95,7 +78,7 @@ const ExperiencesView = () => {
             </h2>
           </div>
           <ExperienceList
-            key={refreshKey}
+            key={experiences.length}
             initialExperiences={loading ? null : experiences}
           />
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import dynamic from 'next/dynamic'
 import Header from './components/Header'
 import Footer from './components/Footer'
 import BottomNav from './components/BottomNav'
+import { getExperiencesWithStats, type Experience } from './actions/experiences'
 
 // Lazy-load each view — they are only downloaded when the user navigates to that tab.
 // This keeps the initial bundle small (the map library alone is ~1 MB).
@@ -29,14 +30,44 @@ function ViewLoader() {
   )
 }
 
+interface ExperienceData {
+  experiences: Experience[]
+  stats: { total: number; countries: number; helpfulVotes: number; thisMonth: number }
+}
+
 export default function Home() {
   const [currentView, setCurrentView] = useState('globe')
+
+  // Fetched once on first Community visit — survives tab switching.
+  // ExperiencesView receives this as props instead of fetching itself.
+  const [experienceData, setExperienceData] = useState<ExperienceData | null>(null)
+  const [experienceLoading, setExperienceLoading] = useState(false)
 
   useEffect(() => {
     if (window.innerWidth < 768) {
       setCurrentView('table')
     }
   }, [])
+
+  // Fetch when Community tab is first opened, or after a new story is submitted
+  const fetchExperienceData = useCallback(async () => {
+    setExperienceLoading(true)
+    try {
+      const data = await getExperiencesWithStats()
+      setExperienceData(data)
+    } catch (e) {
+      console.error('Failed to fetch experiences:', e)
+    } finally {
+      setExperienceLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    // Pre-fetch when user first switches to Community tab
+    if (currentView === 'experiences' && !experienceData && !experienceLoading) {
+      fetchExperienceData()
+    }
+  }, [currentView])
 
   const renderView = () => {
     switch (currentView) {
@@ -45,7 +76,13 @@ export default function Home() {
       case 'table':
         return <TableView />
       case 'experiences':
-        return <ExperiencesView />
+        return (
+          <ExperiencesView
+            initialData={experienceData}
+            loading={experienceLoading}
+            onRefresh={fetchExperienceData}
+          />
+        )
       default:
         return <WorldGlobe onViewChange={setCurrentView} />
     }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -49,7 +49,7 @@ export default function Home() {
     }
   }, [])
 
-  // Fetch when Community tab is first opened, or after a new story is submitted
+  // Fetch (or re-fetch) experience data. Called on page load and after new submissions.
   const fetchExperienceData = useCallback(async () => {
     setExperienceLoading(true)
     try {
@@ -62,12 +62,11 @@ export default function Home() {
     }
   }, [])
 
+  // Prefetch in the background as soon as the page loads — data is tiny (~50 rows)
+  // and will be ready in state before the user ever clicks the Community tab.
   useEffect(() => {
-    // Pre-fetch when user first switches to Community tab
-    if (currentView === 'experiences' && !experienceData && !experienceLoading) {
-      fetchExperienceData()
-    }
-  }, [currentView])
+    fetchExperienceData()
+  }, [])
 
   const renderView = () => {
     switch (currentView) {


### PR DESCRIPTION
Root cause: ExperiencesView fully unmounted on every tab switch (switch statement in renderView), so each visit to Community triggered a fresh DB round-trip — 1-3s on cold Vercel instances.

Fix: fetch experiences once in page.tsx on first Community visit and keep the data in parent state. ExperiencesView now receives initialData/loading/onRefresh as props instead of fetching itself. Tab switches are instant; data only re-fetches after a new story is submitted.