### PR TITLE
Build Telegram → Stories ingestion pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,23 +1,23 @@
-# Environment Variables Example
-# Copy this file to .env and fill in your actual values
+# ── Database ──────────────────────────────────────────────────────────────────
+DATABASE_URL=postgresql://user:password@host/dbname
 
-# Telegram API Configuration (SENSITIVE - keep private)
-TELEGRAM_API_ID=your-telegram-api-id
-TELEGRAM_API_HASH=your-telegram-api-hash
-TELEGRAM_SESSION=your-telegram-session-string
+# ── Telegram Bot ──────────────────────────────────────────────────────────────
+# Get from @BotFather
+TELEGRAM_BOT_TOKEN=123456789:ABCDEFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
-# Google Cloud Configuration (SENSITIVE - keep private)
-GOOGLE_CLOUD_PROJECT=your-project-id
-GOOGLE_AI_MODEL_ID=your-model-id
-GOOGLE_APPLICATION_CREDENTIALS=path/to/your/service-account-key.json
+# Your personal Telegram user ID (get from @userinfobot)
+# Only this ID can approve/reject stories via button clicks
+ADMIN_TELEGRAM_ID=123456789
 
-# Firebase Configuration (Can be public, but better to use env vars)
-# These values are designed to be public, but using env vars is still good practice
-VITE_FIREBASE_API_KEY=your-firebase-api-key
-VITE_FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com
-VITE_FIREBASE_DATABASE_URL=https://your-project-default-rtdb.firebaseio.com
-VITE_FIREBASE_PROJECT_ID=your-project-id
-VITE_FIREBASE_STORAGE_BUCKET=your-project.appspot.com
-VITE_FIREBASE_MESSAGING_SENDER_ID=your-sender-id
-VITE_FIREBASE_APP_ID=your-app-id
-VITE_FIREBASE_MEASUREMENT_ID=your-measurement-id
+# Optional: restrict ingestion to one group only (recommended)
+# Get by adding @userinfobot to your group — it shows the group's chat ID (negative number)
+TELEGRAM_GROUP_ID=-1001234567890
+
+# ── AI providers ──────────────────────────────────────────────────────────────
+# Gemini Flash — primary extractor (free: 1500 req/day)
+# Get from https://aistudio.google.com/app/apikey
+GEMINI_API_KEY=AIzaSy...
+
+# Groq — fallback extractor + primary chat model (free tier)
+# Get from https://console.groq.com/keys
+GROQ_API_KEY=gsk_...

--- a/app/actions/experiences.ts
+++ b/app/actions/experiences.ts
@@ -52,6 +52,7 @@ export const getExperiences = unstable_cache(
     try {
       const result = await sql`
         SELECT * FROM experiences
+        WHERE status = 'published' OR status IS NULL
         ORDER BY created_at DESC
         LIMIT ${PAGE_SIZE}
       `
@@ -75,6 +76,7 @@ export async function loadMoreExperiences(afterId: number): Promise<Experience[]
     const result = await sql`
       SELECT * FROM experiences
       WHERE id < ${afterId}
+        AND (status = 'published' OR status IS NULL)
       ORDER BY created_at DESC
       LIMIT ${PAGE_SIZE}
     `
@@ -85,13 +87,106 @@ export async function loadMoreExperiences(afterId: number): Promise<Experience[]
   }
 }
 
+// ─── Telegram pipeline actions ─────────────────────────────────────────────────
+
+/**
+ * Insert a story extracted from Telegram as pending_review.
+ * Bypasses IP rate limiting — Telegram messages are already filtered.
+ * Returns the new row's ID so the approve button can reference it.
+ */
+export async function insertTelegramExperience(data: {
+  country_code: string
+  country_name: string
+  experience_type: string
+  title: string
+  description: string
+  author_name: string
+  telegram_message_id: number
+}): Promise<{ success: boolean; id?: number; error?: string }> {
+  const sql = getSql()
+  try {
+    const rows = await sql`
+      INSERT INTO experiences (
+        country_code, country_name, experience_type,
+        title, description, author_name,
+        status, source, telegram_message_id
+      ) VALUES (
+        ${data.country_code},
+        ${data.country_name},
+        ${data.experience_type},
+        ${data.title},
+        ${data.description},
+        ${data.author_name},
+        'pending_review',
+        'telegram',
+        ${data.telegram_message_id}
+      )
+      ON CONFLICT (telegram_message_id) DO NOTHING
+      RETURNING id
+    `
+    const id = (rows as { id: number }[])[0]?.id
+    if (!id) return { success: false, error: 'duplicate' }
+    return { success: true, id }
+  } catch (error) {
+    console.error('Error inserting telegram experience:', error)
+    return { success: false, error: String(error) }
+  }
+}
+
+/** Publish a pending story. */
+export async function approveExperience(id: number): Promise<{ success: boolean }> {
+  const sql = getSql()
+  try {
+    await sql`
+      UPDATE experiences
+      SET status = 'published', updated_at = CURRENT_TIMESTAMP
+      WHERE id = ${id}
+    `
+    revalidateTag('experiences')
+    return { success: true }
+  } catch (error) {
+    console.error('Error approving experience:', error)
+    return { success: false }
+  }
+}
+
+/** Reject and delete a pending story. */
+export async function rejectExperience(id: number): Promise<{ success: boolean }> {
+  const sql = getSql()
+  try {
+    await sql`DELETE FROM experiences WHERE id = ${id} AND status = 'pending_review'`
+    return { success: true }
+  } catch (error) {
+    console.error('Error rejecting experience:', error)
+    return { success: false }
+  }
+}
+
+/**
+ * Check if a country already has published stories.
+ * Used by the Telegram pipeline to label notifications (new country vs existing).
+ */
+export async function countStoriesForCountry(countryName: string): Promise<number> {
+  const sql = getSql()
+  try {
+    const rows = await sql`
+      SELECT COUNT(*) as cnt FROM experiences
+      WHERE country_name ILIKE ${countryName}
+        AND (status = 'published' OR status IS NULL)
+    `
+    return Number((rows as { cnt: string }[])[0]?.cnt ?? 0)
+  } catch {
+    return 0
+  }
+}
+
 // Combined fetch — runs both queries in parallel in a single server action call.
 export const getExperiencesWithStats = unstable_cache(
   async (): Promise<{ experiences: Experience[]; stats: ExperienceStats }> => {
     const sql = getSql()
     try {
       const [experiences, statsRows] = await Promise.all([
-        sql`SELECT * FROM experiences ORDER BY created_at DESC LIMIT ${PAGE_SIZE}`,
+        sql`SELECT * FROM experiences WHERE status = 'published' OR status IS NULL ORDER BY created_at DESC LIMIT ${PAGE_SIZE}`,
         sql`
           SELECT
             COUNT(*) as total,

--- a/app/api/telegram/route.ts
+++ b/app/api/telegram/route.ts
@@ -1,90 +1,149 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { extractTravelExperience } from '../../lib/ai';
-import { createExperience } from '../../actions/experiences';
-import { sendTelegramMessage } from '../../lib/telegram';
-import { analyzeMessageLocally } from '../../lib/nlp';
-import { getCode } from 'country-list';
+import { NextRequest, NextResponse } from 'next/server'
+import { getCode } from 'country-list'
+import { extractTravelExperience } from '../../lib/ai'
+import { analyzeMessageLocally } from '../../lib/nlp'
+import { sendTelegramMessage } from '../../lib/telegram'
+import {
+  insertTelegramExperience,
+  approveExperience,
+  rejectExperience,
+  countStoriesForCountry,
+} from '../../actions/experiences'
+
+// Always return 200 to Telegram — if we return anything else it retries endlessly
+const OK = () => NextResponse.json({ ok: true })
 
 export async function POST(req: NextRequest) {
   try {
-    const body = await req.json();
-    const adminId = process.env.ADMIN_TELEGRAM_ID;
+    const body = await req.json()
+    const adminId = process.env.ADMIN_TELEGRAM_ID
+    const groupId = process.env.TELEGRAM_GROUP_ID // optional: restrict to one group
 
-    // --- CASE 1: BUTTON CLICK (CALLBACK QUERY) ---
+    if (!adminId) {
+      console.error('[Telegram] ADMIN_TELEGRAM_ID not set')
+      return OK()
+    }
+
+    // ── CASE 1: Button click (approve / reject) ───────────────────────────────
     if (body.callback_query) {
-      const { data, message, from } = body.callback_query;
-      
-      // Security: Only you can click the buttons
-      if (String(from.id) !== String(adminId)) {
-         return NextResponse.json({ ok: true });
+      const { data, from } = body.callback_query
+
+      // Only the admin can act on buttons
+      if (String(from.id) !== String(adminId)) return OK()
+
+      const callbackId = body.callback_query.id
+
+      if (data?.startsWith('approve_')) {
+        const id = parseInt(data.replace('approve_', ''), 10)
+        const result = await approveExperience(id)
+        await answerCallback(callbackId, result.success ? '✅ Published!' : '❌ Failed')
+        if (result.success) {
+          await sendTelegramMessage(adminId, `✅ Story #${id} is now <b>live</b> on the site.`)
+        }
+      } else if (data?.startsWith('reject_')) {
+        const id = parseInt(data.replace('reject_', ''), 10)
+        const result = await rejectExperience(id)
+        await answerCallback(callbackId, result.success ? '🗑 Rejected' : '❌ Failed')
+        if (result.success) {
+          await sendTelegramMessage(adminId, `🗑 Story #${id} rejected and removed.`)
+        }
       }
 
-      if (data.startsWith('approve_')) {
-        const [_, countryCode, countryName, type] = data.split('|');
-        const originalText = message.text;
-        const description = originalText.split('Description:')[1]?.trim() || "No description";
+      return OK()
+    }
 
-        await createExperience({
-          country_code: countryCode,
-          country_name: countryName,
-          experience_type: type,
-          title: `Report for ${countryName}`,
-          description: `${description}\n\n(Verified from Telegram Community)`,
-          author_name: "Community Member"
-        });
+    // ── CASE 2: Incoming message ───────────────────────────────────────────────
+    const message = body?.message
+    const messageText: string | undefined = message?.text
+    if (!messageText) return OK()
 
-        await sendTelegramMessage(adminId!, `✅ <b>Success!</b> Added report for ${countryName} to the database.`);
-      } else if (data === 'reject') {
-        await sendTelegramMessage(adminId!, `❌ Report rejected and ignored.`);
+    // Optional: only process messages from your community group
+    if (groupId && String(message.chat?.id) !== String(groupId)) return OK()
+
+    const messageId: number = message.message_id
+    const senderName: string = [message.from?.first_name, message.from?.last_name]
+      .filter(Boolean).join(' ') || 'Community Member'
+
+    // ── Step 1: Heuristic filter (free, no API call) ──────────────────────────
+    const local = analyzeMessageLocally(messageText)
+    if (!local.isPotentialReport) {
+      console.log(`[NLP] Skipped: "${messageText.substring(0, 60)}…" — ${local.reason}`)
+      return OK()
+    }
+
+    // ── Step 2: LLM extraction (Gemini Flash → Groq fallback) ─────────────────
+    const extraction = await extractTravelExperience(messageText)
+
+    if (!extraction.isReport || !extraction.country_name) {
+      console.log(`[AI] Not a report: "${messageText.substring(0, 60)}…"`)
+      return OK()
+    }
+
+    // ── Step 3: Save as pending_review ────────────────────────────────────────
+    const countryCode = getCode(extraction.country_name) ?? 'XX'
+    const experienceType = extraction.experience_type ?? 'Visa Required'
+    const title = extraction.title ?? `Report for ${extraction.country_name}`
+    const description = extraction.description ?? messageText
+
+    const insert = await insertTelegramExperience({
+      country_code: countryCode,
+      country_name: extraction.country_name,
+      experience_type: experienceType,
+      title,
+      description: `${description}\n\n— ${senderName} (via Telegram)`,
+      author_name: senderName,
+      telegram_message_id: messageId,
+    })
+
+    if (!insert.success) {
+      // 'duplicate' means we already processed this message — safe to ignore
+      if (insert.error !== 'duplicate') {
+        console.error('[DB] insertTelegramExperience failed:', insert.error)
       }
-      
-      return NextResponse.json({ ok: true });
+      return OK()
     }
 
-    // --- CASE 2: NEW MESSAGE FROM GROUP ---
-    const messageText = body?.message?.text;
-    if (!messageText || !adminId) return NextResponse.json({ ok: true });
+    // ── Step 4: Notify admin with approve / reject buttons ────────────────────
+    const existingCount = await countStoriesForCountry(extraction.country_name)
+    const isNewCountry = existingCount === 0
 
-    // 1. LAYER 1: Local NLP Filter (FREE)
-    const localAnalysis = analyzeMessageLocally(messageText);
-    
-    // Only proceed to LLM if it looks like a real travel report
-    if (!localAnalysis.isPotentialReport) {
-      console.log(`[NLP] Ignored message: "${messageText.substring(0, 50)}..." Reason: ${localAnalysis.reason}`);
-      return NextResponse.json({ ok: true });
-    }
+    const countryLabel = isNewCountry
+      ? `🌍 <b>NEW COUNTRY</b> — first story ever for <b>${extraction.country_name}</b>`
+      : `📖 New story for <b>${extraction.country_name}</b> (${existingCount} existing)`
 
-    // 2. LAYER 2: AI Extraction (PAID/LIMITED)
-    const extraction = await extractTravelExperience(messageText);
+    const notifText = [
+      `${countryLabel}`,
+      ``,
+      `<b>Type:</b> ${experienceType}`,
+      `<b>From:</b> ${senderName}`,
+      `<b>Title:</b> ${title}`,
+      ``,
+      `<b>Description:</b>`,
+      description.substring(0, 400) + (description.length > 400 ? '…' : ''),
+      ``,
+      `Story ID: #${insert.id}`,
+    ].join('\n')
 
-    if (extraction.isReport && extraction.country_name) {
-      const countryCode = getCode(extraction.country_name) || "??";
-      
-      // 3. LAYER 3: Human Approval (YOU)
-      const adminMessage = `
-<b>New Visa Report Detected!</b>
-<b>Confidence Score:</b> ${localAnalysis.confidence}%
-<b>Country:</b> ${extraction.country_name} (${countryCode})
-<b>Type:</b> ${extraction.experience_type}
-<b>User:</b> ${body.message.from?.first_name || "Unknown"}
-<b>Description:</b> ${extraction.description}
+    await sendTelegramMessage(adminId, notifText, {
+      inline_keyboard: [[
+        { text: '✅ Approve', callback_data: `approve_${insert.id}` },
+        { text: '❌ Reject',  callback_data: `reject_${insert.id}`  },
+      ]],
+    })
 
-Should I add this to the website?
-      `;
-
-      const callbackData = `approve_|${countryCode}|${extraction.country_name.substring(0, 15)}|${extraction.experience_type}`;
-
-      await sendTelegramMessage(adminId, adminMessage, {
-        inline_keyboard: [[
-          { text: "✅ Approve", callback_data: callbackData },
-          { text: "❌ Reject", callback_data: "reject" }
-        ]]
-      });
-    }
-
-    return NextResponse.json({ ok: true });
+    return OK()
   } catch (error) {
-    console.error("Webhook Error:", error);
-    return NextResponse.json({ ok: true });
+    console.error('[Telegram webhook] Unhandled error:', error)
+    return OK() // always 200 so Telegram doesn't retry
   }
+}
+
+/** Acknowledge a button click — removes the spinner in Telegram UI */
+async function answerCallback(callbackQueryId: string, text: string) {
+  const token = process.env.TELEGRAM_BOT_TOKEN
+  await fetch(`https://api.telegram.org/bot${token}/answerCallbackQuery`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ callback_query_id: callbackQueryId, text }),
+  }).catch(() => {})
 }

--- a/app/lib/ai.ts
+++ b/app/lib/ai.ts
@@ -1,121 +1,149 @@
-import Groq from "groq-sdk";
-import visaData from '../../data.json';
-import { getExperiences } from '../actions/experiences';
+import { GoogleGenerativeAI } from '@google/generative-ai'
+import Groq from 'groq-sdk'
+import visaData from '../../data.json'
+import { getExperiences } from '../actions/experiences'
 
-let groqInstance: Groq | null = null;
+// ─── Clients (lazily initialised) ─────────────────────────────────────────────
 
-function getGroqClient() {
-  if (!groqInstance) {
-    groqInstance = new Groq({
-      apiKey: process.env.GROQ_API_KEY,
-    });
-  }
-  return groqInstance;
+let _gemini: GoogleGenerativeAI | null = null
+let _groq: Groq | null = null
+
+function getGemini() {
+  if (!_gemini) _gemini = new GoogleGenerativeAI(process.env.GEMINI_API_KEY!)
+  return _gemini
 }
 
+function getGroq() {
+  if (!_groq) _groq = new Groq({ apiKey: process.env.GROQ_API_KEY })
+  return _groq
+}
+
+// ─── Story extraction ──────────────────────────────────────────────────────────
+
+export interface ExtractionResult {
+  isReport: boolean
+  country_name?: string
+  experience_type?: 'Visa Free' | 'E-Visa' | 'Visa Required' | 'Not Recognized'
+  title?: string
+  description?: string
+}
+
+const EXTRACTION_SYSTEM = `You extract RTD (Refugee Travel Document / US I-571) travel experiences from Telegram messages.
+
+Return ONLY a JSON object — no markdown, no explanation.
+
+Schema:
+{
+  "isReport": true | false,
+  "country_name": "full English country name",
+  "experience_type": "Visa Free" | "E-Visa" | "Visa Required" | "Not Recognized",
+  "title": "short one-line summary (max 80 chars)",
+  "description": "what happened at the border / embassy, in the author's words"
+}
+
+If the message is NOT a first-hand travel experience (questions, off-topic, RTD application talk), return {"isReport": false}.`
+
 /**
- * Answers user questions using the Directory and Community Stories as context.
- * Uses a "Search-First" strategy to provide the most relevant data.
+ * Extract a structured story from a raw Telegram message.
+ * Primary: Gemini 1.5 Flash (free, 1500 req/day)
+ * Fallback: Groq Llama 3.1 8B (free, fast)
  */
-export async function askTravelAssistant(query: string) {
+export async function extractTravelExperience(text: string): Promise<ExtractionResult> {
+  // Try Gemini Flash first
   try {
-    const groq = getGroqClient();
-    // 1. Fetch all community stories
-    const allStories = await getExperiences();
-    
-    // 2. Filter context based on the user's query (Basic "Retrieval" logic)
-    // We look for any country mentioned in the query
-    const lowerQuery = query.toLowerCase();
-    
-    // Find matching official rules
-    const relevantOfficial = visaData.filter(item => 
-      lowerQuery.includes(item.country.toLowerCase()) || 
-      (item.country.toLowerCase() === 'united arab emirates' && lowerQuery.includes('dubai')) ||
-      (item.country.toLowerCase() === 'united arab emirates' && lowerQuery.includes('uae'))
-    );
+    const model = getGemini().getGenerativeModel({
+      model: 'gemini-1.5-flash',
+      generationConfig: { responseMimeType: 'application/json' },
+      systemInstruction: EXTRACTION_SYSTEM,
+    })
+    const result = await model.generateContent(text)
+    const json = JSON.parse(result.response.text())
+    return json as ExtractionResult
+  } catch (geminiErr: any) {
+    const isQuota = geminiErr?.status === 429 || String(geminiErr).includes('quota')
+    console.warn(`[AI] Gemini failed (${isQuota ? 'quota' : geminiErr?.message}) — falling back to Groq`)
+  }
 
-    // Find matching community stories
-    const relevantStories = allStories.filter(story => 
-      lowerQuery.includes(story.country_name.toLowerCase())
-    );
-
-    // If no specific country found, give it a small sample of the latest to maintain general knowledge
-    const context = {
-      officialRules: relevantOfficial.length > 0 ? relevantOfficial : visaData.slice(0, 10),
-      communityReports: relevantStories.length > 0 
-        ? relevantStories.slice(0, 10) 
-        : allStories.slice(0, 5)
-    };
-
-    const chatCompletion = await groq.chat.completions.create({
+  // Fallback: Groq Llama 3.1 8B
+  try {
+    const completion = await getGroq().chat.completions.create({
+      model: 'llama-3.1-8b-instant',
+      response_format: { type: 'json_object' },
       messages: [
-        {
-          role: "system",
-          content: `You are the "RTD Travel Assistant" for US Refugee Travel Document (I-571) holders. 
-          
-          CONTEXT (Relevant Official Rules and Community Reports):
-          ${JSON.stringify(context)}
-          
-          GUIDELINES:
-          1. Answer based ON THE CONTEXT. 
-          2. If a specific country is in the Context, give the official rule first, then community reports.
-          3. If the user asks about a city (like Dubai), map it to the country (UAE).
-          4. If the info isn't in the context, say: "I don't have verified data for that country in our community records yet."
-          5. Keep answers to 2-3 concise sentences.`
-        },
-        {
-          role: "user",
-          content: query
-        }
+        { role: 'system', content: EXTRACTION_SYSTEM },
+        { role: 'user', content: text },
       ],
-      model: "llama-3.3-70b-versatile",
-    });
-
-    return chatCompletion.choices[0]?.message?.content || "I'm sorry, I couldn't generate an answer.";
-  } catch (error: any) {
-    console.error("GROQ ERROR:", error);
-    return `AI Error: ${error.message || "Failed to connect"}. Please try again.`;
+    })
+    const raw = completion.choices[0]?.message?.content ?? '{"isReport":false}'
+    return JSON.parse(raw) as ExtractionResult
+  } catch (groqErr) {
+    console.error('[AI] Groq fallback also failed:', groqErr)
+    return { isReport: false }
   }
 }
 
+// ─── Travel assistant chat ─────────────────────────────────────────────────────
+
 /**
- * Extracts structured travel experience data from messy chat text.
+ * Answer RTD travel questions using visa data + community stories as context.
+ * Primary: Groq Llama 3.3 70B (fast, good reasoning)
+ * Fallback: Gemini Flash
  */
-export async function extractTravelExperience(text: string) {
+export async function askTravelAssistant(query: string): Promise<string> {
+  const allStories = await getExperiences()
+  const lowerQuery = query.toLowerCase()
+
+  const relevantOfficial = visaData.filter(item =>
+    lowerQuery.includes(item.country.toLowerCase()) ||
+    (item.country.toLowerCase() === 'united arab emirates' &&
+      (lowerQuery.includes('dubai') || lowerQuery.includes('uae')))
+  )
+  const relevantStories = allStories.filter(s =>
+    lowerQuery.includes(s.country_name.toLowerCase())
+  )
+
+  const context = {
+    officialRules: relevantOfficial.length > 0 ? relevantOfficial : visaData.slice(0, 10),
+    communityReports: relevantStories.length > 0 ? relevantStories.slice(0, 10) : allStories.slice(0, 5),
+  }
+
+  const systemPrompt = `You are the RTD Travel Assistant for US Refugee Travel Document (I-571) holders.
+
+CONTEXT (official rules + community reports):
+${JSON.stringify(context)}
+
+RULES:
+1. Base your answer on the context only.
+2. Give the official rule first, then any community reports.
+3. Map city names to countries (Dubai → UAE).
+4. If a country isn't in the context, say so honestly.
+5. Keep answers to 2-3 concise sentences.`
+
+  // Primary: Groq (faster for chat)
   try {
-    const groq = getGroqClient();
-    const chatCompletion = await groq.chat.completions.create({
+    const completion = await getGroq().chat.completions.create({
+      model: 'llama-3.3-70b-versatile',
       messages: [
-        {
-          role: "system",
-          content: "Extract visa info. Return ONLY a valid JSON object. No markdown, no extra text. Schema: {isReport: boolean, country_name: string, experience_type: string, title: string, description: string}. Ensure all newlines in strings are escaped as \\n."
-        },
-        {
-          role: "user",
-          content: text
-        }
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: query },
       ],
-      model: "llama-3.1-8b-instant",
-      response_format: { type: "json_object" }
-    });
+    })
+    return completion.choices[0]?.message?.content ?? "I couldn't generate an answer."
+  } catch (groqErr: any) {
+    const isQuota = groqErr?.status === 429 || String(groqErr).includes('quota')
+    console.warn(`[AI] Groq chat failed (${isQuota ? 'quota' : groqErr?.message}) — falling back to Gemini`)
+  }
 
-    let content = chatCompletion.choices[0]?.message?.content || '{"isReport": false}';
-    
-    // Clean potential markdown blocks
-    if (content.includes('```')) {
-      content = content.replace(/```json|```/g, '').trim();
-    }
-
-    try {
-      return JSON.parse(content);
-    } catch (parseError) {
-      console.error("JSON Parse Error. Raw Content:", content);
-      // Fallback: try to fix common control character issues
-      const cleanedContent = content.replace(/[\u0000-\u001F\u007F-\u009F]/g, "");
-      return JSON.parse(cleanedContent);
-    }
-  } catch (error) {
-    console.error("Groq Extraction Error:", error);
-    return { isReport: false };
+  // Fallback: Gemini Flash
+  try {
+    const model = getGemini().getGenerativeModel({
+      model: 'gemini-1.5-flash',
+      systemInstruction: systemPrompt,
+    })
+    const result = await model.generateContent(query)
+    return result.response.text()
+  } catch (geminiErr) {
+    console.error('[AI] Gemini chat fallback failed:', geminiErr)
+    return "I'm a bit busy right now — please try again in a moment."
   }
 }

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -48,6 +48,34 @@ async function migrate() {
   `
   console.log('✅ helpful_votes index created')
 
+  // 5. status column — tracks published / pending_review / rejected
+  await sql`
+    ALTER TABLE experiences
+    ADD COLUMN IF NOT EXISTS status VARCHAR(20) DEFAULT 'published'
+  `
+  console.log('✅ experiences.status column added')
+
+  // 6. source column — web | telegram
+  await sql`
+    ALTER TABLE experiences
+    ADD COLUMN IF NOT EXISTS source VARCHAR(20) DEFAULT 'web'
+  `
+  console.log('✅ experiences.source column added')
+
+  // 7. telegram_message_id — deduplication: prevents processing same message twice
+  await sql`
+    ALTER TABLE experiences
+    ADD COLUMN IF NOT EXISTS telegram_message_id BIGINT UNIQUE
+  `
+  console.log('✅ experiences.telegram_message_id column added')
+
+  // 8. Index on status so the published-only filter is fast
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_experiences_status
+    ON experiences(status)
+  `
+  console.log('✅ status index created')
+
   console.log('\n🎉 Migrations complete!')
 }
 


### PR DESCRIPTION
Full pipeline:
1. Heuristic filter (compromise NLP) — free, rejects noise before any API call
2. Gemini 1.5 Flash extraction → Groq Llama fallback if quota/key issue
3. INSERT as pending_review with telegram_message_id for deduplication (ON CONFLICT DO NOTHING prevents double-processing)
4. countStoriesForCountry — labels notification as NEW COUNTRY vs existing
5. Admin notified via Telegram with inline ✅ Approve / ❌ Reject buttons
6. Approve → status=published → revalidateTag → live on site Reject → row deleted

DB: added status, source, telegram_message_id columns (migration). All read queries now filter to published-only stories. Callback data is approve_{id} / reject_{id} — well within Telegram 64-byte limit.